### PR TITLE
Core Debug: collider drawer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,5 +26,7 @@ add_executable(ogre_game
         src/core/physics_world.hpp
         src/core/objects/collider.cpp
         src/core/objects/collider.hpp
+        src/core/collider_drawer.cpp
+        src/core/collider_drawer.hpp
 )
 

--- a/src/core/collider_drawer.cpp
+++ b/src/core/collider_drawer.cpp
@@ -1,0 +1,64 @@
+#include "collider_drawer.hpp"
+
+#include "game.hpp"
+
+core::debug::ColliderDrawer::ColliderDrawer() {
+    m_material = createMaterial();
+    m_manualObject = createManualObject();
+
+    Game::sceneManager()->getRootSceneNode()->attachObject(m_manualObject);
+}
+
+core::debug::ColliderDrawer::~ColliderDrawer() {
+    Game::sceneManager()->destroyManualObject(m_manualObject);
+}
+
+void core::debug::ColliderDrawer::drawLine(const btVector3& from, const btVector3& to, const btVector3& color) {
+    m_lines.emplace_back(Ogre::Vector3(from.x(), from.y(), from.z()));
+    m_lines.emplace_back(Ogre::Vector3(to.x(), to.y(), to.z()));
+}
+
+void core::debug::ColliderDrawer::render() {
+    if (m_lines.empty()) return;
+
+    m_manualObject->clear();
+    m_manualObject->begin(m_material, Ogre::RenderOperation::OT_LINE_LIST);
+
+    for (size_t i = 0; i < m_lines.size(); i++) {
+        m_manualObject->position(m_lines[i]);
+        m_manualObject->colour(0.0, 1.0, 0.0);
+    }
+
+    m_manualObject->end();
+    m_lines.clear();
+}
+
+Ogre::MaterialPtr core::debug::ColliderDrawer::createMaterial() {
+    auto material = Game::materialManager()->create(
+        "CollidersWireframe", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME
+    );
+    material->setReceiveShadows(false);
+    material->setDepthWriteEnabled(false);
+    material->setLightingEnabled(false);
+    material->setCullingMode(Ogre::CULL_NONE);
+
+    auto* pass = material->getTechnique(0)->getPass(0);
+    pass->setDepthCheckEnabled(true);
+    pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+    pass->setPolygonMode(Ogre::PM_WIREFRAME);
+    pass->setDiffuse(1.0, 1.0, 1.0, 1.0);
+
+    pass->setVertexColourTracking(Ogre::TVC_DIFFUSE);
+    pass->setDepthBias(1.0, 1);
+
+    return material;
+}
+
+Ogre::ManualObject* core::debug::ColliderDrawer::createManualObject() {
+    const auto manualObject = Game::sceneManager()->createManualObject("PhysicsDebugDrawer");
+
+    manualObject->setDynamic(true);
+    manualObject->setRenderQueueGroup(Ogre::RENDER_QUEUE_MAIN + 1); // Render colliders after scene
+
+    return manualObject;
+}

--- a/src/core/collider_drawer.hpp
+++ b/src/core/collider_drawer.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <btBulletDynamicsCommon.h>
+
+#include "OgreManualObject.h"
+
+namespace core::debug {
+
+class ColliderDrawer : public btIDebugDraw {
+public:
+    ColliderDrawer();
+
+    ~ColliderDrawer() override;
+
+    void drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override;
+
+    void render();
+
+    int getDebugMode() const override { return DBG_DrawWireframe; }
+
+    // ===
+    // Unused methods
+    // ===
+    void reportErrorWarning(const char* warningString) override {}
+
+    void draw3dText(const btVector3& location, const char* textString) override {}
+
+    void drawContactPoint(const btVector3& PointOnB, const btVector3& normalOnB, btScalar distance, int lifeTime, const btVector3& color) override {}
+
+    void setDebugMode(int debugMode) override {}
+
+private:
+    Ogre::ManualObject* m_manualObject = nullptr;
+    Ogre::MaterialPtr m_material;
+
+    std::vector<Ogre::Vector3> m_lines;
+
+    static Ogre::MaterialPtr createMaterial();
+
+    static Ogre::ManualObject* createManualObject();
+};
+
+} // end namespace core::debug

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -15,8 +15,6 @@ void Game::configure() {
 }
 
 void Game::init() {
-    m_physics = make_shared<PhysicsWorld>();
-
     m_ctx->initApp();
 
     Ogre::Root* root = m_ctx->getRoot();
@@ -24,12 +22,15 @@ void Game::init() {
     root->addMovableObjectFactory(new ColliderFactory);
 
     m_sceneManager = root->createSceneManager();
+    m_materialManager = Ogre::MaterialManager::getSingletonPtr();
 
     const auto shaderGenerator = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
     shaderGenerator->addSceneManager(m_sceneManager);
 
     m_input = make_shared<Input>();
     m_ctx->addInputListener(m_input.get());
+
+    m_physics = make_shared<PhysicsWorld>();
 
     // scene must initiated last
     m_scene->init();

--- a/src/core/game.hpp
+++ b/src/core/game.hpp
@@ -38,15 +38,27 @@ public:
     static OgreBites::ApplicationContext* appContext() { return instance().m_ctx; }
     static Ogre::Root* root() { return instance().m_ctx->getRoot(); }
     static Ogre::SceneManager* sceneManager() { return instance().m_sceneManager; }
+    static Ogre::MaterialManager* materialManager() { return instance().m_materialManager; }
     static shared_ptr<Input> input() { return instance().m_input; }
     static shared_ptr<Scene> scene() { return instance().m_scene; }
     static shared_ptr<PhysicsWorld> physics() { return instance().m_physics; }
+    static bool debugMode() { return instance().m_debugMode; }
 
+    // ===
+    // Setters
+    // ===
     void scene(const shared_ptr<Scene>& scene) { m_scene = scene; }
+    /**
+     * When debug mode is enabled, the game will draw collider shapes
+     */
+    bool debugMode(bool value) { return m_debugMode = value; }
 
 private:
+    bool m_debugMode = false;
+
     OgreBites::ApplicationContext* m_ctx = nullptr;
     Ogre::SceneManager* m_sceneManager = nullptr;
+    Ogre::MaterialManager* m_materialManager = nullptr;
 
     shared_ptr<Input> m_input;
     shared_ptr<Scene> m_scene;

--- a/src/core/physics_world.cpp
+++ b/src/core/physics_world.cpp
@@ -11,8 +11,10 @@ PhysicsWorld::PhysicsWorld() {
         m_dispatcher.get(), m_overlappingPairCache.get(),
         m_solver.get(), m_collisionConfiguration.get()
     );
+    m_colliderDrawer = make_unique<debug::ColliderDrawer>();
 
     m_dynamicsWorld->setGravity(gravity);
+    m_dynamicsWorld->setDebugDrawer(m_colliderDrawer.get());
 }
 
 void PhysicsWorld::addRigidBody(const shared_ptr<btRigidBody>& rigidBody) const {
@@ -24,7 +26,12 @@ void PhysicsWorld::removeRigidBody(const shared_ptr<btRigidBody>& rigidBody) con
 }
 
 void PhysicsWorld::stepSimulation(float dt) const {
-    m_dynamicsWorld->stepSimulation(dt); // TODO: make simulation step every constant seconds
+    // TODO: make simulation step every constant seconds
+    m_dynamicsWorld->stepSimulation(dt);
 }
 
+void PhysicsWorld::drawColliders() const {
+    m_dynamicsWorld->debugDrawWorld();
+    m_colliderDrawer->render();
+}
 } // end namespace core

--- a/src/core/physics_world.hpp
+++ b/src/core/physics_world.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+
+#include "collider_drawer.hpp"
 #include "bullet/btBulletDynamicsCommon.h"
 
 using namespace std;
@@ -25,6 +27,8 @@ public:
      */
     void stepSimulation(float dt) const;
 
+    void drawColliders() const;
+
 private:
     unique_ptr<btDynamicsWorld> m_dynamicsWorld;
 
@@ -39,6 +43,8 @@ private:
     btVector3 gravity = btVector3(0, -10, 0);
 
     btAlignedObjectArray<shared_ptr<btCollisionShape>> collisionShapes;
+
+    unique_ptr<debug::ColliderDrawer> m_colliderDrawer;
 };
 
 } // end namespace core

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -9,4 +9,14 @@ void Scene::init() {
     m_rootNode = m_sceneManager->getRootSceneNode();
 }
 
+bool Scene::frameRenderingQueued(const Ogre::FrameEvent& evt) {
+    Game::physics()->stepSimulation(evt.timeSinceLastFrame);
+
+    if(Game::debugMode()) {
+        Game::physics()->drawColliders();
+    }
+
+    return true;
+}
+
 } // end namespace core

--- a/src/core/scene.hpp
+++ b/src/core/scene.hpp
@@ -12,6 +12,8 @@ public:
 
     Ogre::Camera* mainCamera = nullptr;
 
+    bool frameRenderingQueued(const Ogre::FrameEvent& evt) override;
+
 protected:
     Ogre::SceneNode* m_rootNode = nullptr;
     Ogre::SceneManager* m_sceneManager = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,8 +39,9 @@ class SimpleScene : public core::Scene {
         sinbadNode->attachObject(ent);
         // sinbad collider
         auto sinbadColliderShape = core::Shape(
-            make_shared<btBoxShape>(btVector3(1, 1, 1))
+            make_shared<btBoxShape>(btVector3(2, 4.5, 1))
         );
+        sinbadColliderShape.transform()->setOrigin(btVector3(0, -0.35, 0));
         auto sinbadCollider = dynamic_cast<core::Collider*>(m_sceneManager->createMovableObject("SinbadCollider", "Collider"));
         sinbadCollider->setShapes({ sinbadColliderShape });
         sinbadNode->attachObject(sinbadCollider);
@@ -62,17 +63,11 @@ class SimpleScene : public core::Scene {
         auto groundColliderShape = core::Shape(
             make_shared<btBoxShape>(btVector3(100, 1, 100))
         );
-        groundColliderShape.transform()->setOrigin(btVector3(0, 3, 0));
+        groundColliderShape.transform()->setOrigin(btVector3(0, -1, 0));
         auto groundCollider = dynamic_cast<core::Collider*>(m_sceneManager->createMovableObject("GroundCollider", "Collider"));
         groundCollider->setShapes({ groundColliderShape });
         groundCollider->setMass(0);
         groundNode->attachObject(groundCollider);
-    }
-
-    bool frameRenderingQueued(const Ogre::FrameEvent& evt) override {
-        core::Game::physics()->stepSimulation(evt.timeSinceLastFrame);
-
-        return true;
     }
 };
 
@@ -81,6 +76,7 @@ int main()
     const auto scene = make_shared<SimpleScene>();
 
     auto& game = core::Game::instance();
+    game.debugMode(true);
     game.configure();
     game.scene(scene);
     game.init();


### PR DESCRIPTION
* Implemented collider drawer. It's a debug tool and will not be useful for the player.

- One problem with the collider drawer, is that there's Z-fighting happening when collider is coplanar with the mesh. This is not crucial, so I decided to not fix it (I tried but didn't succeed, so I don't want to spend much time on it)

<img width="974" alt="image" src="https://github.com/user-attachments/assets/9ebfb535-ddb7-4d11-b0d1-bf0ca2dd0868">
