### PR TITLE
Core: Network layer base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,25 @@ add_executable(ogre_game
         src/core/game.hpp
         src/core/scene.cpp
         src/core/scene.hpp
+
         src/core/objects/base_movable_object.hpp
         src/core/objects/free_character_controller.cpp
         src/core/objects/free_character_controller.hpp
-        src/core/physics_world.cpp
-        src/core/physics_world.hpp
         src/core/objects/collider.cpp
         src/core/objects/collider.hpp
+
+        src/core/physics_world.cpp
+        src/core/physics_world.hpp
         src/core/collider_drawer.cpp
         src/core/collider_drawer.hpp
+
+        src/core/network_layer/network_layer_manager.cpp
+        src/core/network_layer/network_layer_manager.hpp
+        src/core/network_layer/network_layer.cpp
+        src/core/network_layer/network_layer.hpp
+        src/core/network_layer/server.cpp
+        src/core/network_layer/server.hpp
+        src/core/network_layer/client.cpp
+        src/core/network_layer/client.hpp
 )
 

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -1,6 +1,5 @@
 #include "game.hpp"
 
-#include "scene.hpp"
 #include "objects/collider.hpp"
 #include "objects/free_character_controller.hpp"
 
@@ -25,13 +24,17 @@ void Game::init() {
     m_materialManager = Ogre::MaterialManager::getSingletonPtr();
     m_renderWindow = m_ctx->getRenderWindow();
 
+    m_input = make_shared<Input>();
+    m_physics = make_shared<PhysicsWorld>();
+    m_networkLayerManager = make_shared<NetworkLayerManager>();
+
+    // TODO: remove this line
+    m_networkLayerManager->init(GameType::SinglePlayer);
+
     const auto shaderGenerator = Ogre::RTShader::ShaderGenerator::getSingletonPtr();
     shaderGenerator->addSceneManager(m_sceneManager);
 
-    m_input = make_shared<Input>();
     m_ctx->addInputListener(m_input.get());
-
-    m_physics = make_shared<PhysicsWorld>();
 
     // scene must initiated last
     m_scene->init();
@@ -39,10 +42,12 @@ void Game::init() {
 }
 
 void Game::start() const {
+    m_networkLayerManager->start();
     m_root->startRendering();
 }
 
 void Game::stop() const {
     m_root->queueEndRendering();
 }
+
 } // end namespace core

--- a/src/core/game.hpp
+++ b/src/core/game.hpp
@@ -3,14 +3,15 @@
 #include <OGRE/Ogre.h>
 #include <OgreApplicationContext.h>
 
+#include "scene.hpp"
 #include "input.hpp"
 #include "physics_world.hpp"
+#include "state_manager.hpp"
+#include "network_layer/network_layer_manager.hpp"
 
 using namespace std;
 
 namespace core {
-
-class Scene;
 
 class Game {
 public:
@@ -46,12 +47,14 @@ public:
     static shared_ptr<Input> input() { return instance().m_input; }
     static shared_ptr<Scene> scene() { return instance().m_scene; }
     static shared_ptr<PhysicsWorld> physics() { return instance().m_physics; }
+    static shared_ptr<NetworkLayerManager> networkLayerManager() { return instance().m_networkLayerManager; }
     static bool debugMode() { return instance().m_debugMode; }
 
     // ===
     // Setters
     // ===
     void scene(const shared_ptr<Scene>& scene) { m_scene = scene; }
+
     /**
      * When debug mode is enabled, the game will draw collider shapes
      */
@@ -69,6 +72,7 @@ private:
     shared_ptr<Input> m_input;
     shared_ptr<Scene> m_scene;
     shared_ptr<PhysicsWorld> m_physics;
+    shared_ptr<NetworkLayerManager> m_networkLayerManager;
 };
 
 } // end namespace core

--- a/src/core/network_layer/client.cpp
+++ b/src/core/network_layer/client.cpp
@@ -1,0 +1,1 @@
+#include "client.hpp"

--- a/src/core/network_layer/client.hpp
+++ b/src/core/network_layer/client.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "network_layer.hpp"
+
+namespace core {
+
+class Client : public INetworkLayer {
+protected:
+    void tick(float dt) override;
+};
+
+} // end namespace core

--- a/src/core/network_layer/network_layer.cpp
+++ b/src/core/network_layer/network_layer.cpp
@@ -1,0 +1,1 @@
+#include "network_layer.hpp"

--- a/src/core/network_layer/network_layer.hpp
+++ b/src/core/network_layer/network_layer.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <thread>
+
+using namespace std;
+
+namespace core {
+
+class INetworkLayer {
+public:
+    virtual ~INetworkLayer() = default;
+
+    void start() {
+        m_running.store(true);
+
+        m_tickThread = thread([this]() {
+            constexpr float dt = MILLISECONDS_BETWEEN_TICKS/1000.;
+            constexpr auto interval = chrono::milliseconds(MILLISECONDS_BETWEEN_TICKS);
+
+            auto nextTick = std::chrono::steady_clock::now();
+
+            while(m_running.load()) {
+                auto now = std::chrono::steady_clock::now();
+
+                if(now >= nextTick) {
+                    tick(dt);
+
+                    nextTick = now + interval;
+                }
+
+                this_thread::sleep_until(nextTick);
+            }
+        });
+    }
+
+    void stop() {
+        m_running.store(false);
+
+        if (m_tickThread.joinable()) {
+            m_tickThread.join();
+        }
+    }
+
+protected:
+    void virtual tick(float dt) = 0;
+
+private:
+    static constexpr int MILLISECONDS_BETWEEN_TICKS = 20;
+
+    atomic<bool> m_running;
+    thread m_tickThread;
+};
+
+} // end namespace core

--- a/src/core/network_layer/network_layer_manager.cpp
+++ b/src/core/network_layer/network_layer_manager.cpp
@@ -1,0 +1,1 @@
+#include "network_layer_manager.hpp"

--- a/src/core/network_layer/network_layer_manager.hpp
+++ b/src/core/network_layer/network_layer_manager.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <memory>
+
+#include "client.hpp"
+#include "server.hpp"
+
+using namespace std;
+
+namespace core {
+
+enum class GameType {
+    None,
+    SinglePlayer,
+    LANHost,
+    LANPeer
+};
+
+class NetworkLayerManager {
+public:
+    NetworkLayerManager() = default;
+
+    void init(GameType gameType) {
+        m_gameType = gameType;
+
+        if(m_networkLayer != nullptr) {
+            m_networkLayer->stop();
+            m_networkLayer.reset();
+        }
+
+        switch (m_gameType) {
+            case GameType::SinglePlayer:
+                m_networkLayer = make_shared<Server>();
+                break;
+
+            case GameType::LANHost:
+            case GameType::LANPeer:
+                throw runtime_error("Not implemented");
+
+            case GameType::None:
+                break;
+        }
+    }
+
+    void start() {
+        m_networkLayer->start();
+    }
+
+private:
+    GameType m_gameType = GameType::None;
+
+    shared_ptr<INetworkLayer> m_networkLayer;
+};
+
+} // end namespace core

--- a/src/core/network_layer/server.cpp
+++ b/src/core/network_layer/server.cpp
@@ -1,0 +1,39 @@
+#include "server.hpp"
+
+#include "../game.hpp"
+#include "../objects/base_movable_object.hpp"
+
+void core::Server::tick(float dt) {
+    simulatePhysics(dt);
+    callFixedUpdate(dt);
+}
+
+void core::Server::simulatePhysics(float dt) {
+    Game::physics()->stepSimulationFixed(dt);
+}
+
+void core::Server::callFixedUpdate(float dt) {
+    queue<Ogre::SceneNode*> q;
+    q.push(Game::sceneManager()->getRootSceneNode());
+
+    // TODO: consider iterating through callbacks, instead of the scene tree
+    while(!q.empty()) {
+        const auto node = q.front();
+        q.pop();
+
+        for(auto child: node->getChildren()) {
+            q.push(static_cast<Ogre::SceneNode*>(child));
+        }
+
+        for(const auto object: node->getAttachedObjects()) {
+            auto binding =  object->getUserObjectBindings().getUserAny();
+
+            if(binding.has_value() == false)
+                continue;
+
+            auto* casted = Ogre::any_cast<BaseMovableObject*>(binding);
+
+            casted->fixedUpdate(dt);
+        }
+    }
+}

--- a/src/core/network_layer/server.hpp
+++ b/src/core/network_layer/server.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "network_layer.hpp"
+
+namespace core {
+
+class Server : public INetworkLayer {
+protected:
+    void tick(float dt) override;
+
+private:
+    void simulatePhysics(float dt);
+
+    void callFixedUpdate(float dt);
+};
+
+};

--- a/src/core/objects/collider.cpp
+++ b/src/core/objects/collider.cpp
@@ -61,12 +61,10 @@ void core::Collider::updateSceneNodeTransform() const {
     getParentNode()->setOrientation(Ogre::Quaternion(rotation.w(), rotation.x(), rotation.y(), rotation.z()));
 }
 
-bool core::Collider::frameRenderingQueued(const Ogre::FrameEvent& evt) {
+void core::Collider::frameRenderingQueued(const Ogre::FrameEvent& evt) {
     if(getParentNode() != nullptr) {
         updateSceneNodeTransform();
     }
-
-    return true;
 }
 
 void core::Collider::objectAttached() {

--- a/src/core/objects/collider.hpp
+++ b/src/core/objects/collider.hpp
@@ -71,7 +71,7 @@ public:
      */
     void updateSceneNodeTransform() const;
 
-    bool frameRenderingQueued(const Ogre::FrameEvent& evt) override;
+    void frameRenderingQueued(const Ogre::FrameEvent& evt) override;
 
 protected:
     void objectAttached() override;

--- a/src/core/objects/free_character_controller.cpp
+++ b/src/core/objects/free_character_controller.cpp
@@ -4,7 +4,7 @@ namespace core {
 
 FreeCameraController::FreeCameraController(const Ogre::String& name): BaseMovableObject(name) {}
 
-bool FreeCameraController::frameRenderingQueued(const Ogre::FrameEvent& evt) {
+void FreeCameraController::frameRenderingQueued(const Ogre::FrameEvent& evt) {
     // rotation
     if(Game::input()->relativeMouse()) {
         // Don't multiply by timeSinceLastFrame because mouseDeltaX/Y are already frame-rate independent
@@ -20,8 +20,6 @@ bool FreeCameraController::frameRenderingQueued(const Ogre::FrameEvent& evt) {
     const float z = Game::input()->deltaY() * evt.timeSinceLastFrame * linearSpeed;
 
     getParentNode()->translate(x, 0, -z, Ogre::Node::TS_LOCAL);
-
-    return true;
 }
 
 } // end namespace core

--- a/src/core/objects/free_character_controller.hpp
+++ b/src/core/objects/free_character_controller.hpp
@@ -20,7 +20,7 @@ public:
 
     const Ogre::String& getMovableType() const override { return FREE_CAMERA_CONTROLLER_TYPE; }
 
-    bool frameRenderingQueued(const Ogre::FrameEvent& evt) override;
+    void frameRenderingQueued(const Ogre::FrameEvent& evt) override;
 };
 
 class FreeCameraControllerFactory : public Ogre::MovableObjectFactory {

--- a/src/core/physics_world.cpp
+++ b/src/core/physics_world.cpp
@@ -26,8 +26,11 @@ void PhysicsWorld::removeRigidBody(const shared_ptr<btRigidBody>& rigidBody) con
 }
 
 void PhysicsWorld::stepSimulation(float dt) const {
-    // TODO: make simulation step every constant seconds
     m_dynamicsWorld->stepSimulation(dt);
+}
+
+void PhysicsWorld::stepSimulationFixed(float dt) const {
+    m_dynamicsWorld->stepSimulation(dt, 0);
 }
 
 void PhysicsWorld::drawColliders() const {

--- a/src/core/physics_world.hpp
+++ b/src/core/physics_world.hpp
@@ -23,9 +23,17 @@ public:
     void removeRigidBody(const shared_ptr<btRigidBody>& rigidBody) const;
 
     /**
-     * Step physics simulation by delta time (seconds)
+     * Step physics simulation by delta time (seconds).
+     * Note: Use when simulate physics on each frame
      */
     void stepSimulation(float dt) const;
+
+    /**
+     * Step physics simulation by constant delta time.
+     * Note: use when simulate physics in a logic thread
+     * @param dt delta time
+     */
+    void stepSimulationFixed(float dt) const;
 
     void drawColliders() const;
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -10,8 +10,6 @@ void Scene::init() {
 }
 
 bool Scene::frameRenderingQueued(const Ogre::FrameEvent& evt) {
-    Game::physics()->stepSimulation(evt.timeSinceLastFrame);
-
     if(Game::debugMode()) {
         Game::physics()->drawColliders();
     }


### PR DESCRIPTION
- Implemented minimum NetworkLayer implementation: NetworkLayerManager, INetworkLayer, server and dummy client
- Now there game runs in two threads: Rendering (Main) and Logic (Server)
- Logic of every MovableObject must be inside FixedUpdate (which is called on the server thread)
- Small refactoring of BaseMovableObject:
     * Removed unnecessary dynamic_casts
     * Removed multiple inheritance
