### PR TITLE
Core: State

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ add_executable(ogre_game
         src/core/collider_drawer.cpp
         src/core/collider_drawer.hpp
 
+        src/core/objects/state.cpp
+        src/core/objects/state.hpp
+
         src/core/network_layer/network_layer_manager.cpp
         src/core/network_layer/network_layer_manager.hpp
         src/core/network_layer/network_layer.cpp

--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -50,4 +50,8 @@ void Game::stop() const {
     m_root->queueEndRendering();
 }
 
+bool Game::debugMode(bool value) {
+    return m_debugMode = value;
+}
+
 } // end namespace core

--- a/src/core/game.hpp
+++ b/src/core/game.hpp
@@ -7,6 +7,7 @@
 #include "input.hpp"
 #include "physics_world.hpp"
 #include "network_layer/network_layer_manager.hpp"
+#include "state_manager.hpp"
 
 using namespace std;
 
@@ -57,7 +58,7 @@ public:
     /**
      * When debug mode is enabled, the game will draw collider shapes
      */
-    bool debugMode(bool value) { return m_debugMode = value; }
+    bool debugMode(bool value);
 
 private:
     bool m_debugMode = false;

--- a/src/core/network_layer/server.cpp
+++ b/src/core/network_layer/server.cpp
@@ -36,6 +36,12 @@ void core::Server::callFixedUpdate(float dt) {
             auto* casted = Ogre::any_cast<BaseMovableObject*>(binding);
 
             casted->fixedUpdate(dt);
+
+            // Here server could store all changes and send them to clients
+
+            if(casted->state() != nullptr) {
+                casted->state()->applyChanges();
+            }
         }
     }
 }

--- a/src/core/objects/base_movable_object.hpp
+++ b/src/core/objects/base_movable_object.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "OgreMovableObject.h"
+#include "state.hpp"
 
 #include "../game.hpp"
 
@@ -16,20 +17,24 @@ namespace core {
  */
 class BaseMovableObject : public Ogre::MovableObject {
 public:
-    BaseMovableObject() { init(); }
-    explicit BaseMovableObject(const Ogre::String& name): MovableObject(name) { init(); }
+    BaseMovableObject()
+        { BaseMovableObject::init(); }
+    explicit BaseMovableObject(const Ogre::String& name): MovableObject(name)
+        { BaseMovableObject::init(); }
 
     /**
      * Invoked at fixed rate. All logic must be implemented here.
      * Note: This function is called in a diffrent thread (not main thread),
      * so be careful about concurrency
-     * @return next state
      */
     virtual void fixedUpdate(float dt) {}
+
+    virtual shared_ptr<State> state() { return nullptr; }
 
     // ===
     // MovableObject overrides
     // ===
+
     const Ogre::AxisAlignedBox& getBoundingBox() const override {
         static Ogre::AxisAlignedBox box;
         return box;
@@ -44,7 +49,8 @@ public:
     void visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables) override {}
 
 protected:
-    void init() {
+
+    void virtual init() {
         setListener(new Listener(this));
         Game::root()->addFrameListener(new FrameListener(this));
 

--- a/src/core/objects/state.cpp
+++ b/src/core/objects/state.cpp
@@ -1,0 +1,1 @@
+#include "state.hpp"

--- a/src/core/objects/state.hpp
+++ b/src/core/objects/state.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <any>
+
+using namespace std;
+
+namespace core {
+
+#define STATE_PROP(type, name)    \
+    public:                       \
+    void name(type value) {       \
+        m_changes[#name] = value; \
+    }                             \
+    type name() {                 \
+        return m_##name;          \
+    }                             \
+    private:                      \
+    type m_##name
+
+// TODO: this is temporary solution. We want to avoid code duplication
+#define STATE_PROP_SETTER(type, name)       \
+    m_setters[#name] = [this](any value) {  \
+        this->name = any_cast<type>(value); \
+    }
+
+class State {
+public:
+    virtual ~State() = default;
+
+    void applyChanges() {
+        for(const auto& [key, value]: m_changes) {
+            m_setters[key](value);
+        }
+
+        m_changes.clear();
+    }
+
+protected:
+    map<string, any> m_changes;
+    map<string, function<void(any)>> m_setters;
+
+    void virtual registerSetters() = 0;
+};
+
+}


### PR DESCRIPTION
- implemented State:
* States props are update after all fixedUpdates completed. That's done this way so we can store state changes, that later server could send to the client for synchronization
* Right now when use State, there will be a duplication of code for props and their setters. I couldn't find an easy work around, but I will resolve it later
