### PR TITLE
Core: Fix Collider and NetworkLayer::updateTimestamp race condition

### DIFF
--- a/src/core/network_layer/network_layer.cpp
+++ b/src/core/network_layer/network_layer.cpp
@@ -16,13 +16,20 @@ void NetworkLayer::start() {
         constexpr auto interval = chrono::milliseconds(MILLISECONDS_BETWEEN_TICKS);
 
         auto nextTick = std::chrono::steady_clock::now();
-        m_currentUpdateTimestamp = utils::getTimestamp();
+
+        {
+            lock_guard _(updateTimestampMutex);
+            m_currentUpdateTimestamp = utils::getTimestamp();
+        }
 
         while(m_running.load()) {
             auto now = std::chrono::steady_clock::now();
 
-            m_previousUpdateTimestamp = m_currentUpdateTimestamp;
-            m_currentUpdateTimestamp = utils::getTimestamp() + MILLISECONDS_BETWEEN_TICKS;
+            {
+                lock_guard _(updateTimestampMutex);
+                m_previousUpdateTimestamp = m_currentUpdateTimestamp;
+                m_currentUpdateTimestamp = utils::getTimestamp() + MILLISECONDS_BETWEEN_TICKS;
+            }
 
             if(now >= nextTick) {
                 tick(dt);

--- a/src/core/network_layer/network_layer.hpp
+++ b/src/core/network_layer/network_layer.hpp
@@ -14,8 +14,21 @@ public:
 
     void stop();
 
-    long long currentUpdateTimestamp() const { return m_currentUpdateTimestamp; }
-    long long previousUpdateTimestamp() const { return m_previousUpdateTimestamp; }
+    /**
+     * Timestamp of the most recent update.
+     */
+    long long currentUpdateTimestamp() {
+        lock_guard _(updateTimestampMutex);
+        return m_currentUpdateTimestamp;
+    }
+
+    /**
+     * The timestamp of the previous update.
+     */
+    long long previousUpdateTimestamp() {
+        lock_guard _(updateTimestampMutex);
+        return m_previousUpdateTimestamp;
+    }
 
 protected:
     void virtual tick(float dt) = 0;
@@ -25,9 +38,14 @@ private:
 
     atomic<bool> m_running;
     thread m_tickThread;
+    // mutex for reading/writing @m_currentUpdateTimestamp, @m_previousUpdateTimestamp
+    mutex updateTimestampMutex;
 
-    long long m_currentUpdateTimestamp = 0.0;
-    long long m_previousUpdateTimestamp = 0.0;
+    // Important note: this is accessed from multiple threads.
+    long long m_currentUpdateTimestamp = 0;
+    // Important note: this is accessed from multiple threads.
+    long long m_previousUpdateTimestamp = 0;
+
 };
 
 } // end namespace core

--- a/src/core/objects/collider.cpp
+++ b/src/core/objects/collider.cpp
@@ -51,9 +51,8 @@ bool Collider::isDynamic() const {
 }
 
 void Collider::resetRigidbodyTransform() const {
-    const auto nodePosition = &getParentNode()->getPosition();
-    const auto nodeRotation = &getParentNode()->getOrientation();
-
+    const auto nodePosition = &getParentNode()->_getDerivedPosition();
+    const auto nodeRotation = &getParentNode()->_getDerivedOrientation();
     btTransform transform;
 
     transform.setOrigin(btVector3(nodePosition->x, nodePosition->y, nodePosition->z));
@@ -73,8 +72,8 @@ void Collider::updateSceneNodeTransform() const {
 
     m_state->getValues(position, rotation);
 
-    getParentNode()->setPosition(position);
-    getParentNode()->setOrientation(rotation);
+    getParentNode()->_setDerivedPosition(position);
+    getParentNode()->_setDerivedOrientation(rotation);
 }
 
 void Collider::fixedUpdate(float dt) {


### PR DESCRIPTION
Fixed two issues:
- Now Collider gets/sets values to the node's **world transform** (before it was local transform)
- Fixed accident app crashes that have been happening, because of race condition to the access of NetworkLayer::m_currentUpdateTimestamp and NetworkLayer::m_previousUpdateTimestamp